### PR TITLE
Upgrade version to 1.1.2

### DIFF
--- a/io.github.bommbomm34.latindefense.yaml
+++ b/io.github.bommbomm34.latindefense.yaml
@@ -17,8 +17,8 @@ modules:
         if [ "$FLATPAK_ARCH" = "aarch64" ]; then
           sed -i 's/x86_64/arm64/' export_presets_flatpak.cfg
         fi
-      - mv Godot_v4.4.1-stable_linux.x86_64 godot || true
-      - mv Godot_v4.4.1-stable_linux.arm64 godot || true
+      - mv Godot_v4.5-stable_linux.x86_64 godot || true
+      - mv Godot_v4.5-stable_linux.arm64 godot || true
       - mv export_presets_flatpak.cfg export_presets.cfg
       - ./godot --headless --export-release "Linux Export" latin-defense
       - install -Dm755 latin-defense /app/bin/latin-defense
@@ -27,19 +27,19 @@ modules:
       - install -Dm644 ./assets/metadata/latin-defense.metainfo.xml /app/share/metainfo/io.github.bommbomm34.latindefense.metainfo.xml
     sources:
       - type: archive
-        url: https://github.com/godotengine/godot/releases/download/4.4.1-stable/Godot_v4.4.1-stable_linux.x86_64.zip
-        sha256: d6e382fb531019f85630c1f485a561a0d20c4a2344b6c3847735cfee7da812aa
+        url: https://github.com/godotengine/godot/releases/download/4.5-stable/Godot_v4.5-stable_linux.x86_64.zip
+        sha256: c7316e1fd782ad276a4d985a7673b5976eaaa8d90561a2bea5289210dc53e9ba
         only-arches: ["x86_64"]
       - type: archive
-        url: https://github.com/godotengine/godot/releases/download/4.4.1-stable/Godot_v4.4.1-stable_linux.arm64.zip
-        sha256: 07e170b208f91a5bd663fae40f2731fdba1ee3380e4fea90a0d0131e0d3522df
+        url: https://github.com/godotengine/godot/releases/download/4.5-stable/Godot_v4.5-stable_linux.arm64.zip
+        sha256: f9f167c0a19cc84385b508c12bd0e7a290dd21a639bce2ed6dcf4647af796589
         only-arches: ["aarch64"]
       - type: archive
-        url: https://github.com/godotengine/godot-builds/releases/download/4.4-stable/Godot_v4.4-stable_export_templates.tpz
+        url: https://github.com/godotengine/godot/releases/download/4.5-stable/Godot_v4.5-stable_export_templates.tpz
         archive-type: zip
-        sha256: 70b6b98b1a5502c01e2aca18e8e567bf044eed8b49d0deb75dfdfca573fe52f8
+        sha256: 375d83b661794f91746d2dec9b569a99d4d24f85a70c4ec0068aafb18b551d53
       - type: git
         url: https://github.com/bommbomm34/latindefense.git
-        commit: 34f83d4ed7dacdb0fd16ace974169e2485093851
+        commit: f27dd892785d95be5e29ddb20ecb40680c8a21f5
 
 


### PR DESCRIPTION
Upgraded to Godot 4.5 and upgraded game to 1.1.2.
See [changelog](https://github.com/bommbomm34/latindefense/releases/tag/v1.1.2) for more details.